### PR TITLE
chore: bump versions to 0.0.4.0

### DIFF
--- a/client/utxorpc-client.cabal
+++ b/client/utxorpc-client.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:           utxorpc-client
-version:        0.0.2.0
+version:        0.0.4.0
 synopsis:       An SDK for clients of the UTxO RPC specification.
 description:    An SDK to reduce boilerplate, improve ease-of-use, and support logging for `utxorpc`.
                 To get started, see the documentation for `Utxorpc.Client` below.

--- a/server/utxorpc-server.cabal
+++ b/server/utxorpc-server.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:           utxorpc-server
-version:        0.0.3.0
+version:        0.0.4.0
 synopsis:       An SDK for UTxO RPC services.
 description:    An SDK to reduce boilerplate, improve ease-of-use, and support logging for `utxorpc`.
                 To get started, see the documentation for `Utxorpc.Server` below.


### PR DESCRIPTION
## Summary
Version bump for both client and server packages to 0.0.4.0

## Changes
- **utxorpc-client**: `0.0.2.0` → `0.0.4.0`
- **utxorpc-server**: `0.0.3.0` → `0.0.4.0`

## Context
This release includes support for utxorpc spec v0.0.18.1 with:
- Updated API for SubmitTx (single transaction instead of list)
- Updated API for SubmitTxResponse (single ref instead of list)
- BigInt type support for various parameter fields
- Additional dependencies for quickstart executable

## Release Process
After merging:
1. Tag with `v0.0.4.0`
2. Push tag to trigger GitHub Actions release workflow
3. Packages will be published to Hackage automatically

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)