### PR TITLE
fix: update test files to use SyncService instead of ChainSyncService

### DIFF
--- a/client/test/logged_test.hs
+++ b/client/test/logged_test.hs
@@ -22,7 +22,7 @@ unaryReq = defMessage
 
 type UnaryReply = FetchBlockResponse
 
-type UnaryRpc = RPC ChainSyncService "fetchBlock"
+type UnaryRpc = RPC SyncService "fetchBlock"
 
 unaryRpc :: UnaryRpc
 unaryRpc = RPC
@@ -37,7 +37,7 @@ type StreamReply = FollowTipResponse
 streamReplies :: Int -> [StreamReply]
 streamReplies n = replicate n defMessage
 
-type StreamRpc = RPC ChainSyncService "followTip"
+type StreamRpc = RPC SyncService "followTip"
 
 streamRpc :: StreamRpc
 streamRpc = RPC

--- a/server/test/logged_test.hs
+++ b/server/test/logged_test.hs
@@ -78,7 +78,7 @@ mockUnaryHandler logF _ _ = do
 unaryHandlerOut :: String
 unaryHandlerOut = "UNARY_HANDLER\n"
 
-unaryRpc :: RPC ChainSyncService "fetchBlock"
+unaryRpc :: RPC SyncService "fetchBlock"
 unaryRpc = RPC
 
 unaryReq :: FetchBlockRequest
@@ -112,7 +112,7 @@ streamHandlerOut index = "STREAM_HANDLER " ++ show index ++ "\n"
 streamHandlerEndOut :: Int -> String
 streamHandlerEndOut index = "STREAM_HANDLER_END " ++ show index ++ "\n"
 
-sStreamRpc :: RPC ChainSyncService "followTip"
+sStreamRpc :: RPC SyncService "followTip"
 sStreamRpc = RPC
 
 type SStreamReq = FollowTipRequest


### PR DESCRIPTION
## Summary
Fix test compilation errors after spec update to v0.18.1

## Changes
- Update `ChainSyncService` → `SyncService` in both client and server test files
- Fixes test suite build failures in CI

## Context
The utxorpc spec v0.18.1 renamed `ChainSyncService` to `SyncService`. The main code was updated but the test files were missed.

Fixes the release workflow failure for v0.0.4.0

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)