### PR TITLE
chore: bump versions to 0.0.4.1

### DIFF
--- a/client/utxorpc-client.cabal
+++ b/client/utxorpc-client.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:           utxorpc-client
-version:        0.0.4.0
+version:        0.0.4.1
 synopsis:       An SDK for clients of the UTxO RPC specification.
 description:    An SDK to reduce boilerplate, improve ease-of-use, and support logging for `utxorpc`.
                 To get started, see the documentation for `Utxorpc.Client` below.

--- a/server/utxorpc-server.cabal
+++ b/server/utxorpc-server.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:           utxorpc-server
-version:        0.0.4.0
+version:        0.0.4.1
 synopsis:       An SDK for UTxO RPC services.
 description:    An SDK to reduce boilerplate, improve ease-of-use, and support logging for `utxorpc`.
                 To get started, see the documentation for `Utxorpc.Server` below.


### PR DESCRIPTION
## Summary
Patch version bump to 0.0.4.1

## Changes
- **utxorpc-client**: `0.0.4.0` → `0.0.4.1`
- **utxorpc-server**: `0.0.4.0` → `0.0.4.1`

## Context
Patch release to fix test compilation issues with spec v0.18.1:
- Fixed ChainSyncService → SyncService renaming in test files

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)