### PR TITLE
feat: bump utxorpc to 0.0.19

### DIFF
--- a/client/utxorpc-client.cabal
+++ b/client/utxorpc-client.cabal
@@ -52,7 +52,7 @@ library
     , http2-grpc-proto-lens < 0.2
     , http2-grpc-types < 0.6
     , proto-lens < 0.8
-    , utxorpc >= 0.0.18 && < 0.0.19
+    , utxorpc >= 0.0.19 && < 0.0.20
     , uuid < 1.4
   default-language: Haskell2010
 
@@ -92,7 +92,7 @@ executable example
     , time < 1.13
     , transformers < 0.7
     , unliftio < 0.3
-    , utxorpc >= 0.0.18 && < 0.0.19
+    , utxorpc >= 0.0.19 && < 0.0.20
     , utxorpc-client
     , uuid < 1.4
   default-language: Haskell2010
@@ -121,7 +121,7 @@ executable quickstart
     , proto-lens < 0.8
     , text < 2.2
     , unliftio < 0.3
-    , utxorpc >= 0.0.18 && < 0.0.19
+    , utxorpc >= 0.0.19 && < 0.0.20
     , utxorpc-client
   default-language: Haskell2010
 
@@ -156,6 +156,6 @@ test-suite unit
     , http2-grpc-types >= 0.5.0.0 && < 0.6
     , hspec >= 2.11.7 && < 2.12
     , proto-lens < 0.8
-    , utxorpc >= 0.0.18 && < 0.0.19
+    , utxorpc >= 0.0.19 && < 0.0.20
     , uuid < 1.4
   default-language: Haskell2010


### PR DESCRIPTION
Bumps the `utxorpc` dependency bounds to `>= 0.0.19 && < 0.0.20` — the Hackage release matching UTxO RPC spec v0.19.0 (haskell uses an independent 0.0.x line). Part of a coordinated cross-cutting spec bump across the u5c SDKs.

**Verification:** manifest bump only — NOT build-verified locally (cabal toolchain unavailable in the bump environment). Please confirm via CI.

Part of the u5c-factory `bump-sdk-spec` queue.