### PR TITLE
fix(deps): bump utxorpc to 0.0.19 for server and stack.yaml

### DIFF
--- a/server/utxorpc-server.cabal
+++ b/server/utxorpc-server.cabal
@@ -51,7 +51,7 @@ library
     , bytestring < 0.13
     , http2-grpc-proto-lens < 0.2
     , http2-grpc-types >= 0.5.0.0 && < 0.6
-    , utxorpc >= 0.0.18 && < 0.0.19
+    , utxorpc >= 0.0.19 && < 0.0.20
     , uuid < 1.4
     , wai < 3.3
     , warp  < 3.5
@@ -95,7 +95,7 @@ executable example
     , time < 1.13
     , transformers < 0.7
     , unliftio < 0.3
-    , utxorpc >= 0.0.18 && < 0.0.19
+    , utxorpc >= 0.0.19 && < 0.0.20
     , utxorpc-server
     , uuid < 1.4
     , wai < 3.3
@@ -134,7 +134,7 @@ test-suite unit
     , hspec >= 2.11.7 && < 2.12
     , proto-lens < 0.8
     , transformers < 0.7
-    , utxorpc >= 0.0.18 && < 0.0.19
+    , utxorpc >= 0.0.19 && < 0.0.20
     , uuid < 1.4
     , wai < 3.3
     , warp-grpc < 0.5

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,10 +6,10 @@ packages:
 
 extra-deps:
   # UTxO RCP codegen
-  - utxorpc-0.0.18.1
+  - utxorpc-0.0.19.0@sha256:564db9f088641c0e48ba58b9e53cfd7c9cb1035eec5a903f5286aead264c6fc4,2466
   # >= 7.2.0 required to support FieldMasks
   - proto-lens-protobuf-types-0.7.2.1
-  # Required by utxorpc-0.0.18.1
+  # Required by utxorpc-0.0.19.0
   - proto-lens-runtime-0.7.0.7@sha256:9144556f1a58945e455dd67431bd16d0bd6b2960732dd9b60aa44dd472123a50,3057
   # required by proto-lens-protobuf-types, no version in snapshot
   - proto-lens-protoc-0.8.0.0


### PR DESCRIPTION
## Problem

The spec-0.19 bump raised `client/utxorpc-client.cabal` to `utxorpc >= 0.0.19`, but left:
- `server/utxorpc-server.cabal` at `utxorpc >= 0.0.18 && < 0.0.19`
- `stack.yaml` pinned at `utxorpc-0.0.18.1`

No single `utxorpc` version satisfies both the client (≥0.0.19) and server (<0.0.19), so `stack build` fails with *"Stack failed to construct a build plan"*.

## Fix

- Bump `server/utxorpc-server.cabal` bounds to `utxorpc >= 0.0.19 && < 0.0.20` (3 occurrences).
- Bump the `stack.yaml` extra-dep to `utxorpc-0.0.19.0` (pinned hash as suggested by Stack).

> Note: if the `utxorpc` 0.0.19 codegen changed message shapes, the server modules may need follow-up changes — CI will surface that.